### PR TITLE
Sets the RVM --binary build_opt based on operatingsystem.

### DIFF
--- a/manifests/rvm.pp
+++ b/manifests/rvm.pp
@@ -5,10 +5,15 @@ class katello_devel::rvm {
 
   rvm::system_user { $katello_devel::user: ; }
 
+  $build_opts = $::operatingsystem ? {
+    'RedHat' => [],
+    default  => ['--binary']
+  }
+
   rvm_system_ruby { 'ruby-1.9.3-p448':
     ensure      => 'present',
     default_use => true,
-    build_opts  => ['--binary'],
+    build_opts  => $build_opts,
   }
 
   rvm_gem { 'bundler':


### PR DESCRIPTION
For some OSes there are binaries available for RVM and some, like RHEL,
there are not. Thus, we set the --binary build_opt only for those
with known binaries and build RVM for others.
