### PR TITLE
Fixes #5467, #5494: Removes reliance on external RVM module and switches...

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,0 +1,5 @@
+name 'katello-katello_devel'
+source 'git://github.com/katello/puppet-katello_devel'
+author 'katello'
+
+dependency 'puppetlabs/vcsrepo'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,17 @@ class katello_devel (
 
   $group = $user
 
+  $changeme = '$6$lb06/IMy$nZhR3LkR2tUunTQm68INFWMyb/8VA2vfYq0/fRzLoKSfuri.vvtjeLJf9V.wuHzw92.aw8NgUlJchMy/qK25x.'
+
+  user { $katello_devel::user:
+    ensure     => present,
+    managehome => true,
+    password   => $changeme,
+  } ~>
+  group { $katello_devel::group:
+    ensure => present
+  }
+
   Class['certs'] ~>
   class { 'certs::apache': } ~>
   class { 'katello_devel::apache': } ~>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,22 +1,22 @@
 # Katello Development Install
 class katello_devel::install {
 
-  include git
-
-  package{ ['pulp-katello-plugins', 'libvirt-devel', 'sqlite-devel', 'postgresql-devel', 'libxslt-devel', 'libxml2-devel']:
+  package{ ['pulp-katello-plugins', 'libvirt-devel', 'sqlite-devel', 'postgresql-devel', 'libxslt-devel', 'libxml2-devel', 'git']:
     ensure => present
   }
 
-  git::repo { 'katello':
-    target => "${katello_devel::deployment_dir}/katello",
-    source => 'https://github.com/Katello/katello.git',
-    user   => $katello_devel::user,
+  vcsrepo { "${katello_devel::deployment_dir}/foreman":
+    ensure    => present,
+    provider  => git,
+    source    => 'https://github.com/theforeman/foreman.git',
+    user      => $katello_devel::user
   }
 
-  git::repo { 'foreman':
-    target => "${katello_devel::deployment_dir}/foreman",
-    source => 'https://github.com/theforeman/foreman.git',
-    user   => $katello_devel::user,
+  vcsrepo { "${katello_devel::deployment_dir}/katello":
+    ensure    => present,
+    provider  => git,
+    source    => 'https://github.com/Katello/katello.git',
+    user      => $katello_devel::user
   }
 
 }

--- a/manifests/rvm.pp
+++ b/manifests/rvm.pp
@@ -1,35 +1,41 @@
 # Setup and create gemset for RVM
 class katello_devel::rvm {
 
-  class { '::rvm': }
+  $install_command = "su -c 'curl -L https://get.rvm.io | bash -s' - ${katello_devel::user}"
 
-  rvm::system_user { $katello_devel::user: ; }
-
-  $build_opts = $::operatingsystem ? {
-    'RedHat' => [],
-    default  => ['--binary']
+  package{ ['curl', 'bash']:
+    ensure => present
   }
 
-  augeas { 'katello_devel-sudo':
+  augeas { 'katello_devel-tty':
     context => '/files/etc/sudoers',
     changes => [
       "set Defaults[type = ':${katello_devel::user}']/type :${katello_devel::user}",
       "set Defaults[type = ':${katello_devel::user}']/requiretty/negate ''",
     ],
-    require => Rvm::System_user[$katello_devel::user],
-  }
-
-  rvm_system_ruby { 'ruby-1.9.3-p448':
-    ensure      => 'present',
-    default_use => true,
-    build_opts  => $build_opts,
-  }
-
-  rvm_gem { 'bundler':
-    ensure       => latest,
-    name         => 'bundler',
-    ruby_version => 'ruby-1.9.3-p448',
-    require      => Rvm_system_ruby['ruby-1.9.3-p448'],
+    require => User[$katello_devel::user],
+  } ->
+  augeas { 'katello_devel-sudo':
+    context => '/files/etc/sudoers',
+    changes => [
+        "set spec[user = '${katello_devel::user}']/user '${katello_devel::user}'",
+        "set spec[user = '${katello_devel::user}']/host_group/host ALL",
+        "set spec[user = '${katello_devel::user}']/host_group/command ALL",
+        "set spec[user = '${katello_devel::user}']/host_group/command/runas_user ALL",
+        "set spec[user = '${katello_devel::user}']/host_group/command/tag NOPASSWD",
+    ],
+    require => User[$katello_devel::user],
+  } ->
+  exec { $install_command:
+    path    => '/usr/bin:/usr/sbin:/bin',
+    creates => "/home/${katello_devel::user}/.rvm/bin/rvm",
+    timeout => 900,
+    require => [ Package['curl'], Package['bash'], User[$katello_devel::user] ],
+  } ->
+  exec { 'install 1.9.3':
+    path    => '/usr/bin:/usr/sbin:/bin',
+    timeout => 900,
+    command => "su -c 'rvm install 1.9.3-p448' - ${katello_devel::user}"
   }
 
 }


### PR DESCRIPTION
... to single user install.

Removes the reliance on an external RVM module to allow installation as
the devel deployment user. Switches to using the 'vcsrepo' puppet module
to alleviate issues with switching directories when cloning. Lastly,
adds user creation and sets the user password to 'changeme' for all
devel deployments.
