### PR TITLE
fixes #5486  prefix and candlepin url incorrect for rhsm template on dev...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,9 @@ class katello_devel (
   Class['certs'] ~>
   class { 'certs::apache': } ~>
   class { 'katello_devel::apache': } ~>
-  class { 'certs::katello': } ~>
+  class { 'certs::katello':
+    deployment_url => '/katello'
+  } ~>
   class { 'katello_devel::install': } ~>
   class { 'katello_devel::config': } ~>
   class { 'katello_devel::database': } ~>


### PR DESCRIPTION
... install
- bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1092474
- pass params to certs::katello class so that the appropriate prefix and candlepin url are created in the template
