### PR TITLE
Fixes #7802 - change order qpid::client and katello::qpid are triggered

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,12 +105,6 @@ class katello_devel (
 
   Class['certs'] ~>
   Class['certs::qpid'] ~>
-  class { 'qpid::client': } ~>
-  class { 'katello::qpid':
-    client_cert  => $certs::qpid::client_cert,
-    client_key   => $certs::qpid::client_key,
-    katello_user => $user
-  } ~>
   class { 'certs::pulp_parent': } ~>
   class { 'pulp':
     oauth_key                   => $katello_devel::oauth_key,
@@ -123,6 +117,12 @@ class katello_devel (
     consumers_ca_cert           => $certs::ca_cert,
     consumers_ca_key            => $certs::ca_key,
     consumers_crl               => $candlepin::crl_file,
+  } ~>
+  class { 'qpid::client': } ~>
+  class { 'katello::qpid':
+    client_cert  => $certs::qpid::client_cert,
+    client_key   => $certs::qpid::client_key,
+    katello_user => $user
   } ~>
   class { 'crane':
     cert    => $certs::ca_cert,


### PR DESCRIPTION
Related pull-requests that fix  #7802
https://github.com/Katello/puppet-katello/pull/45
https://github.com/Katello/puppet-katello_devel/pull/26
https://github.com/Katello/puppet-qpid/pull/11
