### PR TITLE
Create commit-msg hook

### DIFF
--- a/manifests/git_repo.pp
+++ b/manifests/git_repo.pp
@@ -28,4 +28,12 @@ define katello_devel::git_repo(
     user     => $katello_devel::user,
   }
 
+  file { "${katello_devel::deployment_dir}/${title}/.git/hooks/commit-msg":
+    ensure  => file,
+    owner   => $::katello_devel::user,
+    group   => $::katello_devel::group,
+    mode    => '0755',
+    content => template('katello_devel/commit-msg.rb.erb'),
+    require => Vcsrepo["${katello_devel::deployment_dir}/${title}"],
+  }
 }

--- a/templates/commit-msg.rb.erb
+++ b/templates/commit-msg.rb.erb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require 'uri'
+
+file = File.new(ARGV[0], "r")
+while (line = file.gets)
+  if line.chomp.sub(URI.regexp, '').size > 72 && line !~ /^\s{4,}/
+    message = "Commit message is not wrapped at 72nd column\n"
+  end
+end
+file.close
+
+unless message.nil?
+  puts message
+  exit(1)
+end


### PR DESCRIPTION
Small thing to notify people earlier about something prprocessor enforces.

Results in something like:

```bash
[vagrant@centos7-devel katello] (sssss)$ git add -A :/ ; git commit -m 'ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss'   -m 'ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss adsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss'
Commit message is not wrapped at 72nd column
[vagrant@centos7-devel katello] (sssss)$ git commit -m 'sssss'
[sssss a73fe71] sssss
 1 file changed, 1 insertion(+)
[vagrant@centos7-devel katello] (sssss)$ 
```