### PR TITLE
Use Ruby 2.4 by default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class katello_devel::params {
   $post_sync_token = 'test'
 
   $use_rvm = true
-  $rvm_ruby = '2.2.4'
+  $rvm_ruby = '2.4'
   $rvm_branch = 'stable'
 
   $initial_organization = 'Default Organization'

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -15,3 +15,5 @@
 
 # webpack dev server settings
 :webpack_dev_server: false
+
+:rails: 4.2


### PR DESCRIPTION
Mostly motivated by https://github.com/theforeman/foreman/pull/5045, which requires Ruby >= 2.3

To test in forklift:

```yaml
centos7-devel-test:
  box: centos7
  ansible:
    playbook: 'playbooks/devel.yml'
    group: 'devel'
    variables:
      foreman_installer_module_prs: "katello/katello_devel/139"
```