### PR TITLE
Use Rails 5 by default in centos7-devel

### DIFF
--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -15,5 +15,3 @@
 
 # webpack dev server settings
 :webpack_dev_server: false
-
-:rails: 4.2


### PR DESCRIPTION
To test:

```yaml
centos7-devel-test:
  box: centos7
  ansible:
    playbook: 'playbooks/devel.yml'
    group: 'devel'
    variables:
      foreman_installer_module_prs: "katello/katello_devel/140"
```