### PR TITLE
Bundler group names can't handle dashes with symbols

### DIFF
--- a/templates/plugin.local.rb.erb
+++ b/templates/plugin.local.rb.erb
@@ -1,1 +1,1 @@
-gemspec :path => '../<%= scope['plugin'] %>', :development_group => :<%= scope['plugin'] %>_dev, :name => '<%= scope['plugin'] %>'
+gemspec :path => '../<%= scope['plugin'] %>', :development_group => '<%= scope['plugin'] %>_dev', :name => '<%= scope['plugin'] %>'


### PR DESCRIPTION
This allows for plugins like foreman-tasks that have a dash since
it cannot handle:

  :foreman-tasks_dev

But can handle:

  'foreman-tasks_dev'