### PR TITLE
Fix github username still being required

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class katello_devel (
   Array[String] $extra_plugins = $katello_devel::params::extra_plugins,
 ) inherits katello_devel::params {
 
-  $fork_remote_name_real = pick($fork_remote_name, $github_username)
+  $fork_remote_name_real = pick($fork_remote_name, $github_username, $name)
 
   $foreman_dir = "${deployment_dir}/foreman"
 


### PR DESCRIPTION
@ekohl I get errors locally if I don;t supply a github_username given both params are then undef.