### PR TITLE
Add support for Pulp Yum repository metadata signatures

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -179,31 +179,38 @@ class katello_devel (
     require       => Class['katello_devel::database'],
   }
 
+  class { '::certs::repomd_gpg':
+    hostname => $::fqdn,
+    before   => Class['pulp'],
+  }
+
   # TODO: Use katello::pulp
   include certs::qpid_client
   class { 'pulp':
-    messaging_url          => 'ssl://localhost:5671',
-    messaging_ca_cert      => $certs::qpid_client::qpid_client_ca_cert,
-    messaging_client_cert  => $certs::qpid_client::qpid_client_cert,
-    messaging_transport    => 'qpid',
-    messaging_auth_enabled => false,
-    broker_url             => 'qpid://localhost:5671',
-    broker_use_ssl         => true,
-    consumers_crl          => $candlepin::crl_file,
-    manage_broker          => false,
-    manage_httpd           => false,
-    manage_squid           => true,
-    enable_iso             => $enable_file,
-    enable_deb             => $enable_deb,
-    enable_rpm             => $enable_yum,
-    enable_puppet          => $enable_puppet,
-    enable_docker          => $enable_docker,
-    enable_ostree          => $enable_ostree,
-    enable_parent_node     => false,
-    enable_katello         => true,
-    default_password       => 'admin',
-    repo_auth              => true,
-    subscribe              => Class['certs::qpid_client'],
+    messaging_url                    => 'ssl://localhost:5671',
+    messaging_ca_cert                => $certs::qpid_client::qpid_client_ca_cert,
+    messaging_client_cert            => $certs::qpid_client::qpid_client_cert,
+    messaging_transport              => 'qpid',
+    messaging_auth_enabled           => false,
+    broker_url                       => 'qpid://localhost:5671',
+    broker_use_ssl                   => true,
+    consumers_crl                    => $candlepin::crl_file,
+    manage_broker                    => false,
+    manage_httpd                     => false,
+    manage_squid                     => true,
+    enable_iso                       => $enable_file,
+    enable_deb                       => $enable_deb,
+    enable_rpm                       => $enable_yum,
+    yum_gpg_sign_repo_metadata       => true,
+    yum_regenerate_repomd_signatures => ($::certs::regenerate_ca or $::certs::regenerate),
+    enable_puppet                    => $enable_puppet,
+    enable_docker                    => $enable_docker,
+    enable_ostree                    => $enable_ostree,
+    enable_parent_node               => false,
+    enable_katello                   => true,
+    default_password                 => 'admin',
+    repo_auth                        => true,
+    subscribe                        => Class['certs::qpid_client'],
   }
 
   file { '/usr/local/bin/ktest':


### PR DESCRIPTION
See https://github.com/theforeman/puppet-certs/pull/188

This is dependent on the following PRs and will fail unit tests until they are merged:
https://github.com/theforeman/puppet-certs/pull/188
https://github.com/theforeman/puppet-pulp/pull/322