### PR TITLE
Fixes #24106 - Add /pub to no_proxy_uris

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -5,7 +5,7 @@ class katello_devel::apache {
 
   $proxy_pass_https = [
     {
-      'no_proxy_uris' => ['/pulp', '/streamer'],
+      'no_proxy_uris' => ['/pulp', '/streamer', '/pub'],
       'path'          => '/',
       'url'           => "http://localhost:${::katello_devel::rails_port}/",
       'params'        => {'retry' => '0'},


### PR DESCRIPTION
To reproduce:
Navigate to https://kat.tello/pub

Katello will now publish both http and https