### PR TITLE
Refs #24220 - increase recommended pool size for the db

### DIFF
--- a/templates/database.yaml.erb
+++ b/templates/database.yaml.erb
@@ -1,8 +1,8 @@
 development:
   adapter: <%= @db_adapter %>
   database: <%= @db_name %>
+  pool: 10
 <% if @db_type == 'sqlite' -%>
-  pool: 5
   timeout: 5000
 <% else -%>
   username: <%= @db_username %>
@@ -15,8 +15,8 @@ development:
 test:
   adapter: <%= @db_adapter %>
   database: <%= @db_name %>_test
+  pool: 10
 <% if @db_type == 'sqlite' -%>
-  pool: 5
   timeout: 5000
 <% else -%>
   username: <%= @db_username %>
@@ -29,8 +29,8 @@ test:
 production:
   adapter: <%= @db_adapter %>
   database: <%= @db_name %>
+  pool: 10
 <% if @db_type == 'sqlite' -%>
-  pool: 5
   timeout: 5000
 <% else -%>
   username: <%= @db_username %>


### PR DESCRIPTION
Since Rails 5, it seems the webrick is not limited on single request at
a time, which leads to 500s when loading the dasboards, especially with
plugins.

Suggesting to increse the default pool size in the database.yml
to avoid users running into this.