### PR TITLE
Use puma multi-threaded by default in devel

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@
 #
 # $extra_plugins::            Array of Github namespace/repo plugins to setup and configure from git
 #
+# $rails_command::            Customize the command used to start rails
 class katello_devel (
   String $user = $katello_devel::params::user,
   Stdlib::Absolutepath $deployment_dir = $katello_devel::params::deployment_dir,
@@ -92,6 +93,7 @@ class katello_devel (
   String $upstream_remote_name = $katello_devel::params::upstream_remote_name,
   Integer[0, 1000] $qpid_wcache_page_size = $::katello_devel::params::qpid_wcache_page_size,
   Array[String] $extra_plugins = $katello_devel::params::extra_plugins,
+  String $rails_command = $katello_devel::params::rails_command,
 ) inherits katello_devel::params {
 
   $fork_remote_name_real = pick_default($fork_remote_name, $github_username)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,4 +42,6 @@ class katello_devel::params {
   $candlepin_qpid_exchange = 'event'
 
   $qpid_wcache_page_size = 4
+
+  $rails_command='puma -w 5 -p $PORT --preload'
 }

--- a/templates/env.erb
+++ b/templates/env.erb
@@ -1,3 +1,4 @@
 BIND=0.0.0.0
 PORT=<%= scope['katello_devel::rails_port'] %>
+RAILS_STARTUP='<%= scope['katello_devel::rails_command'] %>
 WEBPACK_OPTS='--https --key <%= scope['certs::ca_key'] %> --cert <%= scope['certs::ca_cert'] %> --cacert <%= scope['certs::ca_cert'] %> --host 0.0.0.0 --public <%= @fqdn %>'


### PR DESCRIPTION
So @Izhmash encountered a problem with our dev box with provisioning: when Foreman does an SSH finish template on the host it totally locks up the thread and Foreman won't do anything else (including serving the actual provisioning templates to the host).  This changes our devel config to use puma with 5 workers by default.

I noticed a very big speed-up on a lot of pages by using this configuration, as well.
