### PR TITLE
Bump DB pool size

### DIFF
--- a/templates/database.yaml.erb
+++ b/templates/database.yaml.erb
@@ -1,7 +1,7 @@
 development:
   adapter: <%= @db_adapter %>
   database: <%= @db_name %>
-  pool: 10
+  pool: 20
 <% if @db_type == 'sqlite' -%>
   timeout: 5000
 <% else -%>
@@ -15,7 +15,7 @@ development:
 test:
   adapter: <%= @db_adapter %>
   database: <%= @db_name %>_test
-  pool: 10
+  pool: 20
 <% if @db_type == 'sqlite' -%>
   timeout: 5000
 <% else -%>
@@ -29,7 +29,7 @@ test:
 production:
   adapter: <%= @db_adapter %>
   database: <%= @db_name %>
-  pool: 10
+  pool: 20
 <% if @db_type == 'sqlite' -%>
   timeout: 5000
 <% else -%>


### PR DESCRIPTION
Awhile back, the DB pool size for development was set to 5. This was not enough, and resulted in `ActiveRecord::ConnectionTimeoutError (could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pooled connections were in use)` errors.

The pool size was raised to 10 in https://github.com/theforeman/puppet-katello_devel/pull/165 which helped, but the error would still pop up occasionally when viewing the Katello dashboard.

This commit raises the limit to 20. I have not seen the pool error since raising to 20 on my local environment.