### PR TITLE
Remove redundant symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,5 +20,3 @@ fixtures:
     squid3:        "https://github.com/thias/puppet-squid3.git"
     datacat:       "https://github.com/richardc/puppet-datacat"
     systemd:       "https://github.com/camptocamp/puppet-systemd"
-  symlinks:
-    katello_devel: "#{source_dir}"


### PR DESCRIPTION
With recent versions of puppetlabs_spec_helper this is done automatically