### PR TITLE
Fix ktest single mode

### DIFF
--- a/templates/ktest.sh.erb
+++ b/templates/ktest.sh.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Deplyed with katello_devel scenario
+# Deployed with katello_devel scenario
 
 FOREMAN_PATH=<%= @deployment_dir %>/foreman
 KATELLO_PATH=<%= @deployment_dir %>/katello

--- a/templates/ktest.sh.erb
+++ b/templates/ktest.sh.erb
@@ -20,7 +20,7 @@ then
 
   cd $FOREMAN_PATH
   RAKE_PATH=`bundle show rake`
-  ruby -I"lib:test:${KATELLO_PATH}/test:${KATELLO_PATH}/spec" -I"${RAKE_PATH}/lib" $TEST_FILES $OTHER_OPTS
+  bundle exec ruby -I"lib:test:${KATELLO_PATH}/test:${KATELLO_PATH}/spec" -I"${RAKE_PATH}/lib" $TEST_FILES $OTHER_OPTS
 else
   cd $FOREMAN_PATH
   bundle exec rake test:katello


### PR DESCRIPTION
Due to 3784e5bc9f17c38a3cde9bf2c5e458a88398e5da we need `bundler exec` to
run ruby now.

Thanks to @leewaa, @ekohl and @timogoebel for investigation and fixing.