### PR TITLE
Turn off assets debug

### DIFF
--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -21,3 +21,4 @@
 # webpack dev server settings
 :webpack_dev_server: <%= scope['::katello_devel::webpack_dev_server'] %>
 :webpack_dev_server_https: true
+:assets_debug: false


### PR DESCRIPTION
Turning this off speeds up the development server.

There is very little reason for this flag to be on. UI changes
reload fine with it off. AFAICT the only reason to turn it on
is to debug any of the angular/bastion code in the browser.