### PR TITLE
Fetch keys from the keyserver suggested by rvm

### DIFF
--- a/files/install_rvm.sh
+++ b/files/install_rvm.sh
@@ -5,11 +5,12 @@ RVM_BRANCH=${2:-stable}
 SERVERS=(
     hkp://pgp.mit.edu
     hkp://keys.gnupg.net
+    hkp://pool.sks-keyservers.net
 )
 
 for server in "${SERVERS[@]}"
 do
-    gpg --keyserver ${server} --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+    gpg2 --keyserver ${server} --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
     success=$?
 
     if [ "$success" == "0" ]; then


### PR DESCRIPTION
I keep hitting this error:

```
    [[33m WARN[0m [34m2019-01-30T14:46:30[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/File[/usr/bin/install_rvm.sh]/ensure: defined content as '{md5}eeb021788a828be784bc317b169ff5a4'
    [[32m INFO[0m [34m2019-01-30T14:46:30[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/File[/usr/bin/install_rvm.sh]: Scheduling refresh of Exec[/usr/bin/install_rvm.sh 2.5 stable]
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: directory `/home/vagrant/.gnupg' created
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: new configuration file `/home/vagrant/.gnupg/gpg.conf' created
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: WARNING: options in `/home/vagrant/.gnupg/gpg.conf' are not yet active during this run
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: keyring `/home/vagrant/.gnupg/secring.gpg' created
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: keyring `/home/vagrant/.gnupg/pubring.gpg' created
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: requesting key D39DC0E3 from hkp server pgp.mit.edu
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: requesting key 39499BDB from hkp server pgp.mit.edu
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpgkeys: key 409B6B1796C275462A1703113804BB82D39DC0E3 can't be retrieved
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: /home/vagrant/.gnupg/trustdb.gpg: trustdb created
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: key 39499BDB: public key "Piotr Kuczynski <piotr.kuczynski@gmail.com>" imported
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: no ultimately trusted keys found
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: Total number processed: 1
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg:               imported: 1  (RSA: 1)
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:                                  Dload  Upload   Total   Spent    Left  Speed
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0100   194  100   194    0     0    713      0 --:--:-- --:--:-- --:--:--   713
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: 100 24173  100 24173    0     0  56245      0 --:--:-- --:--:-- --:--:-- 56245
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: Installing RVM with gems: bundler.
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: Downloading https://github.com/rvm/rvm/archive/1.29.4.tar.gz
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: Downloading https://github.com/rvm/rvm/releases/download/1.29.4/1.29.4.tar.gz.asc
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: Signature made Sun 01 Jul 2018 07:41:26 PM UTC using RSA key ID BF04FF17
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: gpg: Can't check signature: No public key
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: GPG signature verification failed for '/home/vagrant/.rvm/archives/rvm-1.29.4.tgz' - 'https://github.com/rvm/rvm/releases/download/1.29.4/1.29.4.tar.gz.asc'! Try to install GPG v2 and then fetch the public key:
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:     sudo gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: or if it fails:
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:     command curl -sSL https://rvm.io/mpapis.asc | sudo gpg2 --import -
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:     command curl -sSL https://rvm.io/pkuczynski.asc | sudo gpg2 --import -
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns:
    [[33m WARN[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  /Stage[main]/Katello_devel::Rvm/Exec[/usr/bin/install_rvm.sh 2.5 stable]/returns: In case of further problems with validation please refer to https://rvm.io/rvm/security
    [[31mERROR[0m [34m2019-01-30T14:47:55[0m [36mverbose[0m]  '/usr/bin/install_rvm.sh 2.5 stable' returned 2 instead of one of [0]
```

I think we need to be using gpg2. For good measure, I also added the server suggested by RVM's warning output as well.