### PR TITLE
Install cyrus-sasl-plain

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 # Katello Development Install
 class katello_devel::install {
 
-  package{ ['libvirt-devel', 'sqlite-devel', 'postgresql-devel', 'libxslt-devel', 'systemd-devel', 'libxml2-devel', 'git', 'npm', 'libcurl-devel', 'gcc-c++', 'libstdc++']:
+  package{ ['cyrus-sasl-plain', 'libvirt-devel', 'sqlite-devel', 'postgresql-devel', 'libxslt-devel', 'systemd-devel', 'libxml2-devel', 'git', 'npm', 'libcurl-devel', 'gcc-c++', 'libstdc++']:
     ensure => present,
   }
 


### PR DESCRIPTION
This fixes qdrouterd:

```
Apr 12 18:16:50 centos7-devel.jturel.example.com qdrouterd[1770]: 2019-04-12 18:16:50.079540 +0000 SERVER (info) Connection to localhost:5671 failed: amqp:unauthorized-access SASL(-4): no mechanism available: No
 worthy mechs found (Authentication failed [mech=none])
```

In relation to: https://github.com/theforeman/puppet-qpid/pull/120