### PR TITLE
Make sure Qpid is in place before Candlepin

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,6 +151,14 @@ class katello_devel (
     }
   }
 
+  class { 'katello::qpid':
+    interface               => 'lo',
+    hostname                => 'localhost',
+    katello_user            => $user,
+    candlepin_event_queue   => $candlepin_event_queue,
+    candlepin_qpid_exchange => $candlepin_qpid_exchange,
+    wcache_page_size        => $qpid_wcache_page_size,
+  } ~>
   class { 'katello::candlepin':
     user_groups   => $group,
     oauth_key     => $oauth_key,
@@ -192,15 +200,6 @@ class katello_devel (
     default_password       => 'admin',
     repo_auth              => true,
     subscribe              => Class['certs::qpid_client'],
-  }
-
-  class { 'katello::qpid':
-    interface               => 'lo',
-    hostname                => 'localhost',
-    katello_user            => $user,
-    candlepin_event_queue   => $candlepin_event_queue,
-    candlepin_qpid_exchange => $candlepin_qpid_exchange,
-    wcache_page_size        => $qpid_wcache_page_size,
   }
 
   file { '/usr/local/bin/ktest':


### PR DESCRIPTION
If rake db:seed is ran before the katello_event_queue bindings are created, Candlepin will be in suspend mode and db:seed will fail. This is breaking the devel box currently

```
2019-05-06 21:41:49,663 [thread=localhost-startStop-1] [=, org=, csid=] INFO  org.candlepin.audit.QpidConnection - AMQP connection factory created.
2019-05-06 21:41:50,611 [thread=localhost-startStop-1] [=, org=, csid=] WARN  org.candlepin.audit.QpidConnection - Closing connection to Qpid since the binding is missing!
2019-05-06 21:41:50,612 [thread=localhost-startStop-1] [=, org=, csid=] INFO  org.candlepin.controller.ModeManagerImpl - Entering new mode SUSPEND for the following reasons: [QPID_MISSING_BINDING]
2019-05-06 21:41:50,612 [thread=localhost-startStop-1] [=, org=, csid=] WARN  org.candlepin.controller.ModeManagerImpl - Candlepin is entering suspend mode for the following reasons: QPID_MISSING_BINDING
2019-05-06 21:41:50,612 [thread=localhost-startStop-1] [=, org=, csid=] INFO  org.candlepin.controller.QpidStatusMonitor - Starting Qpid Status Monitor. Checks will be performed every 10 seconds.
2019-05-06 21:41:50,635 [thread=localhost-startStop-1] [=, org=, csid=] INFO  org.candlepin.audit.ActiveMQContextListener - Candlepin will connect to an embedded Artemis server.
```

This change attempts to ensure that Qpid bits are in place before Candlepin, and I saw that it worked (but only tested once).