### PR TITLE
Remove upper version bounds

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,43 +10,43 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.0.0 < 6.0.0"
+      "version_requirement": ">= 4.0.0"
     },
     {
       "name": "puppet/extlib",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 3.0.0"
     },
     {
       "name": "puppetlabs-apache",
-      "version_requirement": ">= 1.0.0 < 5.0.0"
+      "version_requirement": ">= 1.0.0"
     },
     {
       "name": "puppetlabs-postgresql",
-      "version_requirement": ">= 3.0.0 < 6.0.0"
+      "version_requirement": ">= 3.0.0"
     },
     {
       "name": "puppetlabs-vcsrepo",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0"
     },
     {
       "name": "katello-katello",
-      "version_requirement": ">= 6.1.0 < 9.0.0"
+      "version_requirement": ">= 6.1.0"
     },
     {
       "name": "katello-certs",
-      "version_requirement": ">= 2.0.0 < 6.0.0"
+      "version_requirement": ">= 2.0.0"
     },
     {
       "name": "katello-qpid",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0"
     },
     {
       "name": "katello-candlepin",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 4.0.0"
     },
     {
       "name": "katello-pulp",
-      "version_requirement": ">= 4.3.0 < 6.0.0"
+      "version_requirement": ">= 4.3.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Since we don't publish this module and don't regularly check the dependencies, this is easier to maintain. We basically need the latest versions of a certain module and if they're incompatible, we need to fix them.