### PR TITLE
Revert "Remove --path vendor from bundle commands"

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -22,7 +22,7 @@ class katello_devel::setup (
     }
   }
 
-  katello_devel::bundle { 'install --without mysql:mysql2 --retry 3 --jobs 3':
+  katello_devel::bundle { 'install --without mysql:mysql2 --retry 3 --jobs 3 --path .vendor':
     environment => ['MAKEOPTS=-j'],
   } ->
   katello_devel::bundle { 'exec npm install': } ->


### PR DESCRIPTION
Reverts theforeman/puppet-katello_devel#196

This doesn't work right now. Probably because the Puppet exec doesn't read `GEM_HOME` when running `bundle install`.