### PR TITLE
Make pkill not fail on error

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -38,7 +38,7 @@ class katello_devel::setup (
     } ->
     Class['foreman_proxy::register'] ->
     exec { 'destroy rails server':
-      command   => "/usr/bin/pkill -9 --pidfile ${pidfile}",
+      command   => "/usr/bin/pkill -9 --pidfile ${pidfile} || true",
       logoutput => 'on_failure',
       timeout   => '600',
     }


### PR DESCRIPTION
Just testing this out to unblock this error and see what its hiding :space_invader: 

No need to merge unless you think its a good change to have permanently