### PR TITLE
Turn off redux logging to console

### DIFF
--- a/spec/classes/katello_devel_spec.rb
+++ b/spec/classes/katello_devel_spec.rb
@@ -23,6 +23,7 @@ describe 'katello_devel' do
           'PORT=3000',
           "RAILS_STARTUP='puma -w 5 -p $PORT --preload'",
           "WEBPACK_OPTS='--https --key /etc/pki/katello/private/katello-apache.key --cert /etc/pki/katello/certs/katello-apache.crt --cacert /etc/pki/katello/certs/katello-default-ca.crt --host 0.0.0.0 --public #{facts[:fqdn]}'",
+          "REDUX_LOGGER=false",
         ]) }
       end
 

--- a/templates/env.erb
+++ b/templates/env.erb
@@ -2,3 +2,4 @@ BIND=0.0.0.0
 PORT=<%= scope['katello_devel::rails_port'] %>
 RAILS_STARTUP='<%= scope['katello_devel::rails_command'] %>'
 WEBPACK_OPTS='--https --key <%= scope['certs::apache::apache_key'] %> --cert <%= scope['certs::apache::apache_cert'] %> --cacert <%= scope['certs::apache::ca_cert'] %> --host 0.0.0.0 --public <%= scope['certs::apache::hostname'] %>'
+REDUX_LOGGER=false


### PR DESCRIPTION
This environment variable will remove redux logging to the browser console. With Devtools extensions
and the ability to easily turn it back on, there isn't a need for this to be turned on by default.