### PR TITLE
ktest support multiple files

### DIFF
--- a/templates/ktest.sh.erb
+++ b/templates/ktest.sh.erb
@@ -20,7 +20,7 @@ then
 
   cd $FOREMAN_PATH
   RAKE_PATH=`bundle show rake`
-  bundle exec ruby -I"lib:test:${KATELLO_PATH}/test:${KATELLO_PATH}/spec" -I"${RAKE_PATH}/lib" $TEST_FILES $OTHER_OPTS
+  TEST_FILES=$TEST_FILES bundle exec ruby -I"lib:test:${KATELLO_PATH}/test:${KATELLO_PATH}/spec" -I"${RAKE_PATH}/lib" -e "ENV['TEST_FILES'].split.each {|f| require f}" $TEST_FILES $OTHER_OPTS
 else
   cd $FOREMAN_PATH
   bundle exec rake test:katello


### PR DESCRIPTION
ktest doesn't currently run multiple test files. see the assertion counts in before and after below. The ruby executable only accepts a single .rb file, and that can be worked around be requiring each of the test files through `-e`

Still works with a single file ;)


Before:

```
[vagrant@centos7-devel foreman]$ bundle exec ktest ~/katello/test/services/katello/event_daemon_test.rb ~/katello/test/services/katello/event_monitor/poller_thread_test.rb --seed=53467
-- execute("SET CONSTRAINTS ALL DEFERRED;")
   -> 0.0007s
Run options: --seed=53467

# Running:
...

Finished in 0.595936s, 5.0341 runs/s, 10.0682 assertions/s.

3 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```

After

```
[vagrant@centos7-devel foreman]$ bundle exec ktest ~/katello/test/services/katello/event_daemon_test.rb ~/katello/test/services/katello/event_monitor/poller_thread_test.rb --seed=53467

-- execute("SET CONSTRAINTS ALL DEFERRED;")
   -> 0.0002s
Run options: --seed=53467

# Running:

......

Finished in 0.486018s, 12.3452 runs/s, 16.4603 assertions/s.

6 runs, 8 assertions, 0 failures, 0 errors, 0 skips
```