### PR TITLE
Update devel env logging levels

### DIFF
--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -22,3 +22,15 @@
 :webpack_dev_server: <%= scope['::katello_devel::webpack_dev_server'] %>
 :webpack_dev_server_https: true
 :assets_debug: false
+
+# Individual logging types can be toggled on/off here. See settings.yaml.example for more options
+:loggers:
+  :audit:
+    :enabled: true
+    :level: error
+  :taxonomy:
+    :enabled: true
+    :level: error
+  :dynflow:
+    :enabled: true
+    :level: info


### PR DESCRIPTION
As a developer, I don't see a lot of need to log auditing and taxonomies in debug mode by default. Also, changing dynflow logging level to info will reduce the noise it creates while still logging errors and important information.

The amount of noise they generate to the value the logs create doesn't seem beneficial to developer productivity. These log levels can be easily be changed when needed
