### PR TITLE
initial pulp3 support

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -60,6 +60,17 @@ class katello_devel::apache {
     content => template('katello/pulp-apache-ssl.conf.erb'),
   }
 
+  if $katello_devel::pulp3 {
+    class { 'pulpcore':
+      manage_apache => false,
+    }
+
+    concat::fragment { 'katello-pulpcore':
+      target  => '05-katello.conf',
+      content => template('katello_devel/pulpcore-apache.conf.erb'),
+    }
+  }
+
   $rewrite_to_https = [
     {
       rewrite_cond => [

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,8 @@
 #
 # $npm_timeout::              Timeout for npm install step
 #
+# $pulp3::                    Install Pulp3
+#
 class katello_devel (
   String $user = $katello_devel::params::user,
   Stdlib::Absolutepath $deployment_dir = $katello_devel::params::deployment_dir,
@@ -104,6 +106,7 @@ class katello_devel (
   Array[String] $extra_plugins = $katello_devel::params::extra_plugins,
   String $rails_command = $katello_devel::params::rails_command,
   Integer[0] $npm_timeout = $katello_devel::params::npm_timeout,
+  Boolean $pulp3 = $katello_devel::params::pulp3,
 ) inherits katello_devel::params {
 
   $fork_remote_name_real = pick_default($fork_remote_name, $github_username)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,4 +51,6 @@ class katello_devel::params {
   $rails_command='puma -w 5 -p $PORT --preload'
 
   $npm_timeout = 900
+
+  $pulp3 = false
 }

--- a/templates/pulpcore-apache.conf.erb
+++ b/templates/pulpcore-apache.conf.erb
@@ -1,0 +1,4 @@
+  ProxyPass <%= scope['pulpcore::apache::api_path'] %> <%= scope['pulpcore::apache::api_url'] %>
+  ProxyPassReverse <%= scope['pulpcore::apache::api_path'] %> <%= scope['pulpcore::apache::api_url'] %>
+  ProxyPass <%= scope['pulpcore::apache::content_path'] %> <%= scope['pulpcore::apache::content_url'] %>
+  ProxyPassReverse <%= scope['pulpcore::apache::content_path'] %> <%= scope['pulpcore::apache::content_url'] %>


### PR DESCRIPTION
Adding the option to install pulp3. Installation is handled by puppet-pulpcore with `manage_apache => false`. A template is used to add `ProxyPass{,Reverse}` declarations to `05-katello.conf`.