### PR TITLE
Do not make the candlepin user a db superuser

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -66,10 +66,6 @@ class katello_devel::database {
       superuser     => true,
     }
 
-    postgresql::server::role { 'candlepin':
-      superuser => true,
-    }
-
     postgresql::server::db { $db_name:
       user     => $db_username,
       password => $db_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,9 +174,7 @@ class katello_devel (
     wcache_page_size => $qpid_wcache_page_size,
   }
 
-  class { 'katello::candlepin':
-    require => Class['katello_devel::database'],
-  }
+  include katello::candlepin
 
   # TODO: Use katello::pulp
   include certs::qpid_client


### PR DESCRIPTION
There is no need for candlepin to be a superuser and the katello::candlepin class can manage it for us