### PR TITLE
Add Katello user to qpidd group

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,6 +178,8 @@ class katello_devel (
     require => Class['katello_devel::database'],
   }
 
+  User<|title == $user|>{groups +> 'qpidd'}
+
   # TODO: Use katello::pulp
   include certs::qpid_client
   class { 'pulp':


### PR DESCRIPTION
Devels can't spin up properly as the rails server which now connects to qpid can't read the certs resulting in a fatal error while registering the smart proxy:

```
2020-01-08T19:22:19 [I|app|7b843db3] Katello event daemon started process=16908
2020-01-08T19:22:19 [I|app|7b843db3] Processing by Api::V2::SmartProxiesController#index as JSON
2020-01-08T19:22:19 [I|app|7b843db3]   Parameters: {"search"=>"name=\"centos7-luna-devel.dhcp-2-154.example.com\"", "apiv"=>"v2", "smart_proxy"=>{}}
terminate called after throwing an instance of 'qpid::types::Exception'
  what():  Failed to initialise SSL: Failed: NSS error [-8015] (/builddir/build/BUILD/qpid-cpp-1.39.0/src/qpid/sys/ssl/util.cpp:100) (/builddir/build/BUILD/qpid-cpp-1.39.0/src/qpid/client/SslConnector.cpp:149)
Aborted
```

```
[vagrant@centos7-luna-devel katello]$ certutil -L -d /etc/pki/katello/nssdb
certutil: function failed: SEC_ERROR_LEGACY_DATABASE: The certificate/key database is in an old, unsupported format.
```