### PR TITLE
katello/certs 7.x compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -181,7 +181,11 @@ class katello_devel (
   User<|title == $user|>{groups +> 'qpidd'}
 
   # TODO: Use katello::pulp
-  include certs::qpid_client
+  class { 'certs::qpid_client':
+    require => Class['pulp::install'],
+    notify  => Class['pulp::service'],
+  }
+
   class { 'pulp':
     messaging_url          => 'ssl://localhost:5671',
     messaging_ca_cert      => $certs::qpid_client::qpid_client_ca_cert,
@@ -204,7 +208,6 @@ class katello_devel (
     enable_katello         => true,
     default_password       => 'admin',
     repo_auth              => true,
-    subscribe              => Class['certs::qpid_client'],
   }
 
   file { '/usr/local/bin/ktest':


### PR DESCRIPTION
certs 7.0.0 started to create qpid files owned by the pulp group. This group is created by pulp-server which is in pulp::install. This more specific chaining avoids dependency cycles.

This is an alternative to https://github.com/theforeman/puppet-certs/pull/270. Related to https://github.com/theforeman/puppet-certs/pull/272.