### PR TITLE
Use foreman apache configs to unblock Pulp 3

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,100 +1,18 @@
 # Setups Apache for Katello development
 class katello_devel::apache {
 
-  include apache
-
-  $priority = '05'
-
-  $proxy_pass_https = [
-    {
-      'no_proxy_uris' => ['/pulp', '/streamer', '/pub'],
-      'path'          => '/',
-      'url'           => "http://localhost:${katello_devel::rails_port}/",
-      'params'        => {'retry' => '0'},
-    },
-    {
-      'path'          => '/',
-      'url'           => 'http://localhost:6006/',
-      'params'        => {'retry' => '0'},
-    },
-  ]
-
-  file { "${apache::confd_dir}/${priority}-foreman-ssl.d":
-    ensure  => 'directory',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    purge   => true,
-    recurse => true,
+  class { 'foreman::config::apache':
+    passenger     => false,
+    ssl           => true,
+    ssl_cert      => $certs::apache::apache_cert,
+    ssl_key       => $certs::apache::apache_key,
+    ssl_ca        => $certs::apache::ca_cert,
+    ssl_chain     => $certs::apache::apache_ca_cert,
+    proxy_backend => "http://localhost:${katello_devel::rails_port}/",
   }
 
-  apache::vhost { 'katello-ssl':
-    servername            => $certs::apache::hostname,
-    serveraliases         => $certs::apache::cname,
-    docroot               => '/var/www',
-    port                  => 443,
-    priority              => $priority,
-    options               => ['SymLinksIfOwnerMatch'],
-    ssl                   => true,
-    ssl_cert              => $certs::apache::apache_cert,
-    ssl_key               => $certs::apache::apache_key,
-    ssl_ca                => $certs::apache::ca_cert,
-    ssl_verify_client     => 'optional',
-    ssl_options           => '+StdEnvVars',
-    ssl_verify_depth      => '3',
-    custom_fragment       => file('katello/katello-apache-ssl.conf'),
-    additional_includes   => ["${apache::confd_dir}/${priority}-foreman-ssl.d/*.conf"],
-    use_optional_includes => true,
-    ssl_proxyengine       => true,
-    proxy_pass            => $proxy_pass_https,
-    proxy_preserve_host   => true,
-    request_headers       => ["set X_FORWARDED_PROTO 'https'"],
-  }
-
-  # used in template below
-  $pub_dir_options = '+FollowSymLinks +Indexes'
-
-  concat::fragment { 'katello-ssl-pulp':
-    target  => '05-katello-ssl.conf',
-    order   => 271,
-    content => template('katello/pulp-apache-ssl.conf.erb'),
-  }
-
-  $rewrite_to_https = [
-    {
-      rewrite_cond => [
-        '%{REQUEST_URI} !^\/pulp\/.*',
-        '%{REQUEST_URI} !^\/pulp$',
-        '%{REQUEST_URI} !^\/pub\/.*',
-        '%{REQUEST_URI} !^\/pub$',
-        '%{REQUEST_URI} !^\/unattended\/.*',
-        '%{REQUEST_URI} !^\/unattended$',
-        '%{REQUEST_URI} !^\/streamer\/.*',
-        '%{REQUEST_URI} !^\/streamer$',
-        '%{HTTPS} off',
-      ],
-      rewrite_rule => ['(.*) https://%{SERVER_NAME}$1 [L,R=301]'],
-    },
-  ]
-
-  $proxy_pass_http = [
-    {
-      'path' => '/unattended',
-      'url'  => "http://localhost:${katello_devel::rails_port}/unattended",
-    },
-  ]
-
-  apache::vhost { 'katello':
-    servername      => $facts['fqdn'],
-    serveraliases   => ['katello'],
-    docroot         => '/var/www/html',
-    port            => 80,
-    priority        => '05',
-    options         => ['SymLinksIfOwnerMatch'],
-    ssl             => false,
-    rewrites        => $rewrite_to_https,
-    proxy_pass      => $proxy_pass_http,
-    custom_fragment => template('katello/pulp-apache.conf.erb'),
+  foreman::config::apache::fragment { 'katello':
+    ssl_content => file('katello/katello-apache-ssl.conf'),
   }
 
   User<|title == apache|>{groups +> $katello_devel::group}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,37 +178,9 @@ class katello_devel (
     require => Class['katello_devel::database'],
   }
 
+  class { 'katello::pulp': }
+
   User<|title == $user|>{groups +> 'qpidd'}
-
-  # TODO: Use katello::pulp
-  class { 'certs::qpid_client':
-    require => Class['pulp::install'],
-    notify  => Class['pulp::service'],
-  }
-
-  class { 'pulp':
-    messaging_url          => 'ssl://localhost:5671',
-    messaging_ca_cert      => $certs::qpid_client::qpid_client_ca_cert,
-    messaging_client_cert  => $certs::qpid_client::qpid_client_cert,
-    messaging_transport    => 'qpid',
-    messaging_auth_enabled => false,
-    broker_url             => 'qpid://localhost:5671',
-    broker_use_ssl         => true,
-    consumers_crl          => $candlepin::crl_file,
-    manage_broker          => false,
-    manage_httpd           => false,
-    manage_squid           => true,
-    enable_iso             => $enable_file,
-    enable_deb             => $enable_deb,
-    enable_rpm             => $enable_yum,
-    enable_puppet          => $enable_puppet,
-    enable_docker          => $enable_docker,
-    enable_ostree          => $enable_ostree,
-    enable_parent_node     => false,
-    enable_katello         => true,
-    default_password       => 'admin',
-    repo_auth              => true,
-  }
 
   file { '/usr/local/bin/ktest':
     ensure  => file,


### PR DESCRIPTION
This module had declared it's own vhost using a similar naming convention and directory structure as Foreman's. This causes a conflict when pulpcore is enabled since pulpcore relies on adding fragments to Foreman's vhost declaration specifically around the use of `05-foreman-ssl.d`. To solve this, and bring greater continuity I have attempted to declare the `foreman::config::apache` class and re-use it here.