### PR TITLE
Drop unused post_sync_url

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,7 +142,6 @@ class katello_devel (
 
   include certs
 
-  $foreman_url = "https://${facts['fqdn']}/"
   $candlepin_url = $katello::params::candlepin_url
   $candlepin_ca_cert = $certs::ca_cert
   $pulp_url      = "https://${facts['fqdn']}/pulp/api/v2/"

--- a/templates/katello.yaml.erb
+++ b/templates/katello.yaml.erb
@@ -4,8 +4,6 @@
 :katello:
   :rest_client_timeout: 3600
 
-  :post_sync_url: <%= scope['katello_devel::foreman_url'] %>api/v2/repositories/sync_complete?token=<%= scope['katello_devel::post_sync_token'] %>
-
   :content_types:
     :file: <%= scope['katello_devel::enable_file']%>
     :yum: <%= scope['katello_devel::enable_yum']%>


### PR DESCRIPTION
Katello 3.9 dropped this setting