### PR TITLE
Add postgresql-evr extension

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 # Katello Development Install
 class katello_devel::install {
 
-  package{ ['cyrus-sasl-plain', 'libvirt-devel', 'sqlite-devel', "${katello_devel::scl_postgresql}-postgresql-devel", 'libxslt-devel', 'systemd-devel', 'libxml2-devel', 'git', "${katello_devel::scl_nodejs}-npm", 'libcurl-devel', 'gcc-c++', 'libstdc++']:
+  package{ ['cyrus-sasl-plain', 'libvirt-devel', 'sqlite-devel', "${katello_devel::scl_postgresql}-postgresql-devel", 'libxslt-devel', 'systemd-devel', 'libxml2-devel', 'git', "${katello_devel::scl_nodejs}-npm", 'libcurl-devel', 'gcc-c++', 'libstdc++', "${katello_devel::scl_postgresql}-postgresql-evr"]:
     ensure => present,
   }
 


### PR DESCRIPTION
Adds the postgresql-evr extension needed for the upcoming `evt_t` postgresql type.  This won't work out of the box until the package is built in release but it is in staging currently.