### PR TITLE
Drop --without mysql:mysql2 from bundle

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -23,7 +23,7 @@ class katello_devel::setup (
     }
   }
 
-  katello_devel::bundle { 'install --without mysql:mysql2 --retry 3 --jobs 3 --path .vendor':
+  katello_devel::bundle { 'install --retry 3 --jobs 3 --path .vendor':
     environment => ['MAKEOPTS=-j'],
   } ->
   katello_devel::bundle { 'exec npm install':


### PR DESCRIPTION
These groups have been removed and serve no more purpose.