### PR TITLE
Add vagrant user to tomcat group instead of qpidd

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -189,7 +189,7 @@ class katello_devel (
 
   class { 'katello::pulp': }
 
-  User<|title == $user|>{groups +> 'qpidd'}
+  User<|title == $user|>{groups +> 'tomcat'}
 
   file { '/usr/local/bin/ktest':
     ensure  => file,


### PR DESCRIPTION
The event daemon is currently broken in new dev setups:


```
15:33:18 rails.1   | 2020-07-20T15:33:18 [E|app|0336d91d] Error occurred while starting Katello::CandlepinEventListener                                                                       
15:33:18 rails.1   | 2020-07-20T15:33:18 [E|app|0336d91d] client cert file can not be read                                                                                                    
15:33:18 rails.1   | 2020-07-20T15:33:18 [E|app|0336d91d] /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/connection/netio.rb:390:in `open_ssl_socket'
15:33:18 rails.1   |  | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/connection/netio.rb:520:in `open_socket'                                                                
15:33:18 rails.1   |  | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/connection/utils.rb:116:in `block in socket'                                                            
15:33:18 rails.1   |  | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/connection/utils.rb:109:in `synchronize'                                                                
15:33:18 rails.1   |  | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/connection/utils.rb:109:in `socket'                                                                     
15:33:18 rails.1   |  | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/stomp/connection.rb:173:in `initialize'                                                                 
15:33:18 rails.1   |  | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/stomp/client.rb:134:in `new'                                                                            
15:33:18 rails.1   |  | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/stomp/client.rb:134:in `create_connection'                                                              
15:33:18 rails.1   |  | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/stomp/client.rb:101:in `block in initialize'                                                            
15:33:18 rails.1   |  | /opt/rh/rh-ruby25/root/usr/share/ruby/timeout.rb:93:in `block in timeout'                                                                                             
15:33:18 rails.1   |  | /opt/rh/rh-ruby25/root/usr/share/ruby/timeout.rb:33:in `block in catch'                                                                                               15:33:18 rails.1   |  | /opt/rh/rh-ruby25/root/usr/share/ruby/timeout.rb:33:in `catch'                                                                                                        
15:33:18 rails.1   |  | /opt/rh/rh-ruby25/root/usr/share/ruby/timeout.rb:33:in `catch'                                                                                                        
15:33:18 rails.1   |  | /opt/rh/rh-ruby25/root/usr/share/ruby/timeout.rb:108:in `timeout'                                                                                                     
15:33:18 rails.1   |  | /home/vagrant/foreman/.vendor/ruby/2.5.0/gems/stomp-1.4.9/lib/stomp/client.rb:99:in `initialize' 
```

Note groups of the client certs used for the artemis connection:

```
[vagrant@centos7-katello-devel foreman]$ ll /etc/pki/katello/private/java-client.key
-r--r-----. 1 root tomcat 3243 Jul 20 14:40 /etc/pki/katello/private/java-client.key
[vagrant@centos7-katello-devel foreman]$ ll /etc/pki/katello/certs/java-client.crt 
-r--r-----. 1 root tomcat 8262 Jul 20 14:40 /etc/pki/katello/certs/java-client.crt
[vagrant@centos7-katello-devel foreman]$ 
```