### PR TITLE
Override candlepin client cert+key to devel user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -190,8 +190,6 @@ class katello_devel (
 
   class { 'katello::pulp': }
 
-  User<|title == $user|>{groups +> 'qpidd'}
-
   file { '/usr/local/bin/ktest':
     ensure  => file,
     content => template('katello_devel/ktest.sh.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,25 +123,6 @@ class katello_devel (
 
   $qpid_hostname = 'localhost'
 
-  class { 'katello::globals':
-    enable_ostree => $enable_ostree,
-    enable_yum    => $enable_yum,
-    enable_file   => $enable_file,
-    enable_puppet => $enable_puppet,
-    enable_docker => $enable_docker,
-    enable_deb    => $enable_deb,
-  }
-
-  class { 'katello::params':
-    candlepin_oauth_key    => $oauth_key,
-    candlepin_oauth_secret => $oauth_secret,
-    qpid_hostname          => $qpid_hostname,
-  }
-
-  $fork_remote_name_real = pick_default($fork_remote_name, $github_username)
-
-  $foreman_dir = "${deployment_dir}/foreman"
-
   $group = $user
 
   $changeme = '$6$lb06/IMy$nZhR3LkR2tUunTQm68INFWMyb/8VA2vfYq0/fRzLoKSfuri.vvtjeLJf9V.wuHzw92.aw8NgUlJchMy/qK25x.'
@@ -154,6 +135,26 @@ class katello_devel (
   group { $group:
     ensure => present,
   }
+
+  class { 'katello::globals':
+    enable_ostree => $enable_ostree,
+    enable_yum    => $enable_yum,
+    enable_file   => $enable_file,
+    enable_puppet => $enable_puppet,
+    enable_docker => $enable_docker,
+    enable_deb    => $enable_deb,
+  }
+
+  class { 'katello::params':
+    candlepin_oauth_key            => $oauth_key,
+    candlepin_oauth_secret         => $oauth_secret,
+    candlepin_client_keypair_group => $group,
+    qpid_hostname                  => $qpid_hostname,
+  }
+
+  $fork_remote_name_real = pick_default($fork_remote_name, $github_username)
+
+  $foreman_dir = "${deployment_dir}/foreman"
 
   include certs
 


### PR DESCRIPTION
To test, define a nightly devel box which uses staging repos, and applies this PR and the two related ones:

```
centos7-katello-devel-staging:                                                                                                                                
  box: centos7                                                                                                                                                
  ansible:                                                                                                                                                    
    playbook: 'playbooks/katello_devel.yml'                                                                                                                   
    group: 'devel'                                                                                                                                            
    variables:                                                                                                                                                
      ssh_forward_agent: true                                                                                                                                 
      katello_repositories_environment: staging                                                                                                               
      foreman_repositories_environment: staging                                                                                                               
      foreman_installer_module_prs:                                                                                                                           
        - theforeman/certs/295                                                                                                                                
        - theforeman/katello/358                                                                                                                              
        - theforeman/katello_devel/241
```

There should be no errors from CandlepinEventListener in the rails log, and you should see 'Subscribed to Subscribed to katello.candlepin.candlepin_events' rather than a stack trace as you'd see without the 3 PRs applied

For completeness, ensure all services are OK via the ping api: GET /api/v2/ping