### PR TITLE
turn katello_applicability on by default

### DIFF
--- a/templates/katello.yaml.erb
+++ b/templates/katello.yaml.erb
@@ -3,6 +3,7 @@
 
 :katello:
   :rest_client_timeout: 3600
+  :katello_applicability: true
 
   :content_types:
     :file: <%= scope['katello_devel::enable_file']%>


### PR DESCRIPTION
as pulp3 is being used for yum