### PR TITLE
Drop Pulp 2 + enable deb support by default

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,23 +8,19 @@ fixtures:
       puppet_version: '>= 6.0.0'
     vcsrepo:       "https://github.com/puppetlabs/puppetlabs-vcsrepo.git"
     postgresql:    "https://github.com/puppetlabs/puppetlabs-postgresql.git"
-    mongodb:       "https://github.com/voxpupuli/puppet-mongodb.git"
     concat:        "https://github.com/puppetlabs/puppetlabs-concat.git"
     xinetd:        "https://github.com/puppetlabs/puppetlabs-xinetd.git"
     certs:         "https://github.com/theforeman/puppet-certs.git"
     katello:       "https://github.com/theforeman/puppet-katello.git"
     candlepin:     "https://github.com/theforeman/puppet-candlepin.git"
-    pulp:          "https://github.com/theforeman/puppet-pulp.git"
     qpid:          "https://github.com/theforeman/puppet-qpid.git"
     foreman:       "https://github.com/theforeman/puppet-foreman.git"
     foreman_proxy: "https://github.com/theforeman/puppet-foreman_proxy.git"
     redis:         "https://github.com/voxpupuli/puppet-redis"
     tftp:          "https://github.com/theforeman/puppet-tftp.git"
-    squid:         "https://github.com/voxpupuli/puppet-squid.git"
     datacat:       "https://github.com/richardc/puppet-datacat"
     selinux:       "https://github.com/voxpupuli/puppet-selinux"
     selinux_core:
       repo: 'https://github.com/puppetlabs/puppetlabs-selinux_core'
       puppet_version: '>= 6.0.0'
     systemd:       "https://github.com/camptocamp/puppet-systemd"
-    transition:    "https://github.com/puppetlabs/puppetlabs-transition.git"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,6 @@ class katello_devel::config(
   $user = $katello_devel::user,
   $group = $katello_devel::group,
   $extra_plugins = $katello_devel::extra_plugins,
-  Boolean $pulp2_support = $katello::params::pulp2_support,
   String $katello_scm_revision = $katello_devel::katello_scm_revision,
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,17 +47,11 @@
 # @param admin_password
 #   Admin user password for Web application
 #
-# @param enable_ostree
-#   Enable ostree content plugin, this requires an ostree install
-#
 # @param enable_yum
 #   Enable rpm content plugin, including syncing of yum content
 #
 # @param enable_file
 #   Enable generic file content management
-#
-# @param enable_puppet
-#   Enable puppet content plugin
 #
 # @param enable_docker
 #   Enable docker content plugin
@@ -107,10 +101,8 @@ class katello_devel (
   String $initial_organization = $katello_devel::params::initial_organization,
   String $initial_location = $katello_devel::params::initial_location,
   String $admin_password = $katello_devel::params::admin_password,
-  Boolean $enable_ostree = $katello_devel::params::enable_ostree,
   Boolean $enable_yum = $katello_devel::params::enable_yum,
   Boolean $enable_file = $katello_devel::params::enable_file,
-  Boolean $enable_puppet = $katello_devel::params::enable_puppet,
   Boolean $enable_docker = $katello_devel::params::enable_docker,
   Boolean $enable_deb = $katello_devel::params::enable_deb,
   Optional[String] $github_username = $katello_devel::params::github_username,
@@ -141,10 +133,8 @@ class katello_devel (
   }
 
   class { 'katello::globals':
-    enable_ostree => $enable_ostree,
     enable_yum    => $enable_yum,
     enable_file   => $enable_file,
-    enable_puppet => $enable_puppet,
     enable_docker => $enable_docker,
     enable_deb    => $enable_deb,
   }
@@ -164,10 +154,6 @@ class katello_devel (
 
   $candlepin_url = $katello::params::candlepin_url
   $candlepin_ca_cert = $certs::ca_cert
-  $pulp_url      = "https://${facts['networking']['fqdn']}/pulp/api/v2/"
-  $pulp_ca_cert = $certs::ca_cert
-  $crane_url = "https://${facts['networking']['fqdn']}:5000"
-  $crane_ca_cert = $certs::ca_cert
 
   include certs::pulp_client
   include katello::qpid_client
@@ -191,12 +177,8 @@ class katello_devel (
 
   include katello::candlepin
 
-  if $katello::params::pulp2_support {
-    class { 'katello::pulp': }
-
-    class { 'katello::qpid':
-      wcache_page_size => $qpid_wcache_page_size,
-    }
+  class { 'katello::qpid':
+    wcache_page_size => $qpid_wcache_page_size,
   }
 
   User<|title == $user|>{groups +> 'qpidd'}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,10 +33,8 @@ class katello_devel::params {
   $initial_organization = 'Default Organization'
   $initial_location = 'Default Location'
   $admin_password = 'changeme'
-  $enable_ostree = $facts['os']['release']['major'] == '7'
   $enable_yum = true
   $enable_file = true
-  $enable_puppet = $facts['os']['release']['major'] == '7'
   $enable_docker = true
   $enable_deb = $facts['os']['release']['major'] == '7'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,7 @@ class katello_devel::params {
   $enable_yum = true
   $enable_file = true
   $enable_docker = true
-  $enable_deb = $facts['os']['release']['major'] == '7'
+  $enable_deb = true
 
   $github_username = undef
   $use_ssh_fork = false

--- a/metadata.json
+++ b/metadata.json
@@ -43,10 +43,6 @@
     {
       "name": "katello-candlepin",
       "version_requirement": ">= 4.0.0"
-    },
-    {
-      "name": "katello-pulp",
-      "version_requirement": ">= 4.3.0"
     }
   ],
   "requirements": [

--- a/spec/classes/katello_devel_spec.rb
+++ b/spec/classes/katello_devel_spec.rb
@@ -9,6 +9,8 @@ describe 'katello_devel' do
         let(:params) do
           {
             :user => 'vagrant',
+            :oauth_key => 'OAUTH_KEY',
+            :oauth_secret => 'OAUTH_SECRET',
           }
         end
 
@@ -25,6 +27,34 @@ describe 'katello_devel' do
           "WEBPACK_OPTS='--https --key /etc/pki/katello/private/katello-apache.key --cert /etc/pki/katello/certs/katello-apache.crt --cacert /etc/pki/katello/certs/katello-default-ca.crt --host 0.0.0.0 --public #{facts[:fqdn]}'",
           "REDUX_LOGGER=false",
         ]) }
+
+        it do
+          verify_exact_contents(catalogue, '/home/vagrant/foreman/config/settings.plugins.d/katello.yaml', [
+            ':katello:',
+            '  :rest_client_timeout: 3600',
+            '  :katello_applicability: true',
+            '  :content_types:',
+            '    :file: true',
+            '    :yum: true',
+            '    :deb: true',
+            '    :puppet: false',
+            '    :docker: true',
+            '    :ostree: false',
+            '  :candlepin:',
+            '    :url: https://localhost:23443/candlepin',
+            '    :oauth_key: OAUTH_KEY',
+            '    :oauth_secret: OAUTH_SECRET',
+            '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
+            '  :candlepin_events:',
+            '    :ssl_cert_file: /etc/pki/katello/certs/java-client.crt',
+            '    :ssl_key_file: /etc/pki/katello/private/java-client.key',
+            '    :ssl_ca_file: /etc/pki/katello/certs/katello-default-ca.crt',
+            '  :agent:',
+            '    :broker_url: amqp:ssl:localhost:5671',
+            '    :event_queue_name: katello.agent',
+            '  :katello_applicability: true',
+          ])
+        end
       end
 
       describe 'with github_username' do

--- a/templates/katello.yaml.erb
+++ b/templates/katello.yaml.erb
@@ -9,9 +9,9 @@
     :file: <%= scope['katello_devel::enable_file']%>
     :yum: <%= scope['katello_devel::enable_yum']%>
     :deb: <%= scope['katello_devel::enable_deb']%>
-    :puppet: <%= scope['katello_devel::enable_puppet']%>
+    :puppet: false
     :docker: <%= scope['katello_devel::enable_docker']%>
-    :ostree: <%= scope['katello_devel::enable_ostree']%>
+    :ostree: false
 
   :candlepin:
     :url: <%= scope['katello_devel::candlepin_url'] %>
@@ -25,14 +25,3 @@
     :ssl_ca_file: <%= scope['katello_devel::candlepin_ca_cert'] %>
 
   :katello_applicability: true
-
-<% if scope['katello_devel::config::pulp2_support'] %>
-  :pulp:
-    :url: <%= scope['katello_devel::pulp_url'] %>
-    :ca_cert_file: <%= scope['katello_devel::pulp_ca_cert'] %>
-
-  # Internal configuration for communication from server to pulp crane service.
-  :container_image_registry:
-    :crane_url: <%= scope['katello_devel::crane_url'] %>
-    :crane_ca_cert_file: <%= scope['katello_devel::crane_ca_cert'] %>
-<% end %>

--- a/templates/katello.yaml.erb
+++ b/templates/katello.yaml.erb
@@ -24,4 +24,8 @@
     :ssl_key_file: <%= scope['certs::candlepin::client_key'] %>
     :ssl_ca_file: <%= scope['katello_devel::candlepin_ca_cert'] %>
 
+  :agent:
+    :broker_url: <%= scope['katello::params::qpid_url'] %>
+    :event_queue_name: <%= scope['katello::params::agent_event_queue_name'] %>
+
   :katello_applicability: true


### PR DESCRIPTION
This follows what was done in puppet-katello and puppet-foreman_proxy_content.