### PR TITLE
Ensure qpid-proton-c-devel is installed

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -21,6 +21,7 @@ class katello_devel::install {
       'make',
       katello_devel::package('ruby-devel', $katello_devel::scl_ruby),
       katello_devel::package('rubygem-bundler', $katello_devel::scl_ruby),
+      'qpid-proton-c-devel',
     ]:
       ensure => present,
   }


### PR DESCRIPTION
Katello recently started to talk to qpid again to support katello-agent. This needs a devel package to be present.

I should note that I didn't check this myself, but I'm going on the [report in forklift](https://github.com/theforeman/forklift/issues/1288#issuecomment-776605202).