### PR TITLE
Fix bundler deprecation warning in ktest

### DIFF
--- a/templates/ktest.sh.erb
+++ b/templates/ktest.sh.erb
@@ -19,7 +19,7 @@ then
   done
 
   cd $FOREMAN_PATH
-  RAKE_PATH=`bundle show rake`
+  RAKE_PATH=`bundle info rake --path`
   TEST_FILES=$TEST_FILES bundle exec ruby -I"lib:test:${KATELLO_PATH}/test:${KATELLO_PATH}/spec" -I"${RAKE_PATH}/lib" -e "ENV['TEST_FILES'].split.each {|f| require f}" $TEST_FILES $OTHER_OPTS
 else
   cd $FOREMAN_PATH


### PR DESCRIPTION
The warning was:

[DEPRECATED] use `bundle info rake` instead of `bundle show rake`                                                                                                                             
