### PR TITLE
Remove duplicate declaration of package: cyrus-sasl-plain

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,6 @@
 class katello_devel::install {
 
   package{ [
-      'cyrus-sasl-plain',
       'libvirt-devel',
       'sqlite-devel',
       katello_devel::package('postgresql-devel', $katello_devel::scl_postgresql),


### PR DESCRIPTION
The package 'cyrus-sasl-plain' is declared twice for dev box:

https://github.com/theforeman/puppet-katello_devel/blob/master/manifests/install.pp
https://github.com/theforeman/puppet-qpid/blob/master/manifests/install.pp#L21

This throws a duplicate declaration error on vagrant up of katello dev boxes.