### PR TITLE
Refs #33956 - proxy assets and webpack to Rails in devel

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -8,6 +8,7 @@ class katello_devel::apache {
     ssl_ca        => $certs::apache::ca_cert,
     ssl_chain     => $certs::apache::apache_ca_cert,
     proxy_backend => "http://localhost:${katello_devel::rails_port}/",
+    proxy_assets  => true,
   }
 
   # required by configuration in katello/katello-apache-ssl.conf


### PR DESCRIPTION
In https://github.com/theforeman/puppet-foreman/commit/215db6539dbfdbd2896946537f1e520fac7f63ba we made a change that `/webpack` and `/assets` are served by Apache by default. This is correct for production setups, but breaks development ones, as here `/assets` is actually served by Rails.

Explicitly configure `foreman::apache` to not include these in the "no_proxy" list.