### PR TITLE
Allow plugin source repositories to be unmanaged

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,7 @@ class katello_devel::config (
   Stdlib::Absolutepath $foreman_dir = $katello_devel::foreman_dir,
   String $user = $katello_devel::user,
   String $group = $katello_devel::group,
-  Array[String] $extra_plugins = $katello_devel::extra_plugins,
+  Array[Variant[String,Hash]] $extra_plugins = $katello_devel::extra_plugins,
   String $katello_scm_revision = $katello_devel::katello_scm_revision,
 ) {
   file { "${foreman_dir}/.env":
@@ -34,5 +34,14 @@ class katello_devel::config (
     settings_template => 'katello_devel/katello.yaml.erb',
     scm_revision      => $katello_scm_revision,
   }
-  katello_devel::plugin { $extra_plugins: }
+
+  $extra_plugins.each |$plugin| {
+    if is_hash($plugin) {
+      katello_devel::plugin { $plugin['name']:
+        manage_repo => $plugin['manage_repo'],
+      }
+    } else {
+      katello_devel::plugin { $plugin: }
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,7 +82,7 @@ class katello_devel (
   Optional[String] $fork_remote_name = undef,
   String $upstream_remote_name = 'upstream',
   Integer[0, 1000] $qpid_wcache_page_size = 4,
-  Array[String] $extra_plugins = $katello_devel::params::extra_plugins,
+  Array[Variant[String,Hash]] $extra_plugins = $katello_devel::params::extra_plugins,
   String $rails_command = 'puma -w 2 -p $PORT --preload',
   Integer[0] $npm_timeout = 2700,
   String $foreman_scm_revision = 'develop',

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -6,9 +6,13 @@
 #
 # @param scm_revision
 #   The Branch or revision to use when doing the git checkout
+#
+# @param manage_repo
+#   Set to false if the plugin source repository is managed externally.
 define katello_devel::plugin (
   Optional[String] $settings_template = undef,
   Optional[String] $scm_revision = undef,
+  Boolean $manage_repo = true,
 ) {
   $split_array = split($name, '/')
   $github_organization = $split_array[0]
@@ -32,9 +36,11 @@ define katello_devel::plugin (
     mode    => '0644',
   }
 
-  katello_devel::git_repo { $plugin:
-    source          => $title,
-    github_username => $katello_devel::github_username,
-    revision        => $scm_revision,
+  if $manage_repo {
+    katello_devel::git_repo { $plugin:
+      source          => $title,
+      github_username => $katello_devel::github_username,
+      revision        => $scm_revision,
+    }
   }
 }

--- a/spec/classes/katello_devel_spec.rb
+++ b/spec/classes/katello_devel_spec.rb
@@ -142,6 +142,36 @@ describe 'katello_devel' do
         it { is_expected.to contain_class('Foreman_proxy::Register') }
         it { is_expected.to contain_katello_devel__bundle('exec rails s -d') }
       end
+
+      describe 'extra plugins' do
+        context 'with foo plugin' do
+          let(:params) do
+            {
+              :user => 'vagrant',
+              :extra_plugins => ['theforeman/foo'],
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_katello_devel__plugin('theforeman/foo') }
+          it { is_expected.to contain_katello_devel__git_repo('foo') }
+        end
+
+        context 'with an additional plugin with unmanaged source repository' do
+          let(:params) do
+            {
+              :user => 'vagrant',
+              :extra_plugins => ['theforeman/foo', { 'name' => 'customorg/bar', 'manage_repo' => false }],
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_katello_devel__plugin('theforeman/foo') }
+          it { is_expected.to contain_katello_devel__git_repo('foo') }
+          it { is_expected.to contain_katello_devel__plugin('customorg/bar') }
+          it { is_expected.not_to contain_katello_devel__git_repo('bar') }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This approach allows plugins to be defined optionally by a Hash instead of a String.

This is useful when working with a plugin that differs from the plugin source on github, or if it is not (yet) available on github at all.

It is also provides all the machinery needed in the plugin class to allow for an unmanaged Katello repository, via a trivial follow up commit.

This all can be useful also if the user prefers to manage their source repositories directly in forklift or via any other external approach.

Without this capability, the installer will either overwrite the user's changes or it will fail with an error.