### PR TITLE
Allow Katello source repository to be unmanaged

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,7 @@ class katello_devel::config (
   String $group = $katello_devel::group,
   Array[Variant[String,Hash]] $extra_plugins = $katello_devel::extra_plugins,
   String $katello_scm_revision = $katello_devel::katello_scm_revision,
+  Boolean $katello_manage_repo = $katello_devel::katello_manage_repo,
 ) {
   file { "${foreman_dir}/.env":
     ensure  => file,
@@ -33,6 +34,7 @@ class katello_devel::config (
   katello_devel::plugin { 'katello/katello':
     settings_template => 'katello_devel/katello.yaml.erb',
     scm_revision      => $katello_scm_revision,
+    manage_repo       => $katello_manage_repo,
   }
 
   $extra_plugins.each |$plugin| {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,8 @@
 # @param katello_scm_revision
 #   Branch or revision to use for katello's git checkout
 #
+# @param katello_manage_repo
+#   Manage the Katello git repository
 class katello_devel (
   String $user = undef,
   Stdlib::Absolutepath $deployment_dir = '/home/vagrant',
@@ -87,6 +89,7 @@ class katello_devel (
   Integer[0] $npm_timeout = 2700,
   String $foreman_scm_revision = 'develop',
   String $katello_scm_revision = 'master',
+  Boolean $katello_manage_repo = true,
 ) inherits katello_devel::params {
   $qpid_hostname = 'localhost'
 

--- a/spec/classes/katello_devel_spec.rb
+++ b/spec/classes/katello_devel_spec.rb
@@ -20,6 +20,8 @@ describe 'katello_devel' do
 
         it { is_expected.to contain_class('katello_devel::install') }
         it { is_expected.to contain_class('katello_devel::config') }
+        it { is_expected.to contain_katello_devel__plugin('katello/katello') }
+        it { is_expected.to contain_katello_devel__git_repo('katello') }
         it { is_expected.to contain_class('katello_devel::database') }
         it { is_expected.not_to contain_katello_devel__bundle('exec rails s -d') }
         it { is_expected.to contain_file('/usr/local/bin/ktest').with_content(%r{^FOREMAN_PATH=/home/vagrant/foreman$}) }
@@ -170,6 +172,19 @@ describe 'katello_devel' do
           it { is_expected.to contain_katello_devel__git_repo('foo') }
           it { is_expected.to contain_katello_devel__plugin('customorg/bar') }
           it { is_expected.not_to contain_katello_devel__git_repo('bar') }
+        end
+
+        context 'with unmanaged katello repo' do
+          let(:params) do
+            {
+              :user => 'vagrant',
+              :katello_manage_repo => false,
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_katello_devel__plugin('katello/katello') }
+          it { is_expected.not_to contain_katello_devel__git_repo('katello') }
         end
       end
     end


### PR DESCRIPTION
This builds on #287 and allows the Katello repository specifically to be unmanaged