### PR TITLE
Add plugin scm version

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,7 +40,8 @@ class katello_devel::config (
   $extra_plugins.each |$plugin| {
     if is_hash($plugin) {
       katello_devel::plugin { $plugin['name']:
-        manage_repo => $plugin['manage_repo'],
+        manage_repo  => $plugin['manage_repo'],
+        scm_revision => $plugin['scm_revision'],
       }
     } else {
       katello_devel::plugin { $plugin: }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,7 +38,7 @@ class katello_devel::config (
   }
 
   $extra_plugins.each |$plugin| {
-    if is_hash($plugin) {
+    if $plugin =~ Hash {
       katello_devel::plugin { $plugin['name']:
         manage_repo  => $plugin['manage_repo'],
         scm_revision => $plugin['scm_revision'],

--- a/spec/classes/katello_devel_spec.rb
+++ b/spec/classes/katello_devel_spec.rb
@@ -186,6 +186,22 @@ describe 'katello_devel' do
           it { is_expected.not_to contain_katello_devel__git_repo('bar') }
         end
 
+        context 'with an additional plugin with specified repository branch' do
+          let(:params) do
+            {
+              :user => 'vagrant',
+              :extra_plugins => ['theforeman/foo', { 'name' => 'customorg/bar', 'scm_revision' => '1.2.3-stable' }],
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_katello_devel__plugin('theforeman/foo') }
+          it { is_expected.to contain_katello_devel__git_repo('foo') }
+          it { is_expected.to contain_katello_devel__plugin('customorg/bar') }
+          it { is_expected.to contain_katello_devel__git_repo('bar').with_source('customorg/bar') }
+          it { is_expected.to contain_katello_devel__git_repo('bar').with_revision('1.2.3-stable') }
+        end
+
         context 'with unmanaged katello repo' do
           let(:params) do
             {


### PR DESCRIPTION
Allow specifying an scm-branch for `extra_plugins`.

This will come in handy, if `foreman_scm_revision` and `katello_scm_revision` are specified to a version that requires a non-default-branch version of the `extra_plugins`.