### PR TITLE
Add foreman_remote_execution to default repos

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,9 @@ class katello_devel::config (
   String $group = $katello_devel::group,
   Array[Variant[String,Hash]] $extra_plugins = $katello_devel::extra_plugins,
   String $katello_scm_revision = $katello_devel::katello_scm_revision,
+  String $rex_scm_revision = $katello_devel::rex_scm_revision,
   Boolean $katello_manage_repo = $katello_devel::katello_manage_repo,
+  Boolean $rex_manage_repo = $katello_devel::rex_manage_repo,
 ) {
   file { "${foreman_dir}/.env":
     ensure  => file,
@@ -35,6 +37,11 @@ class katello_devel::config (
     settings_template => 'katello_devel/katello.yaml.erb',
     scm_revision      => $katello_scm_revision,
     manage_repo       => $katello_manage_repo,
+  }
+
+  katello_devel::plugin { 'theforeman/foreman_remote_execution':
+    scm_revision      => $rex_scm_revision,
+    manage_repo       => $rex_manage_repo,
   }
 
   $extra_plugins.each |$plugin| {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,11 +62,17 @@
 # @param katello_scm_revision
 #   Branch or revision to use for katello's git checkout
 #
+# @param rex_scm_revision
+#   Branch or revision to use for foreman_remote_execution's git checkout
+#
 # @param foreman_manage_repo
 #   Manage the Foreman git repository
 #
 # @param katello_manage_repo
 #   Manage the Katello git repository
+#
+# @param rex_manage_repo
+#   Manage the Foreman Remote Execution git repository
 class katello_devel (
   String $user = undef,
   Stdlib::Absolutepath $deployment_dir = '/home/vagrant',
@@ -88,8 +94,10 @@ class katello_devel (
   Integer[0] $npm_timeout = 2700,
   String $foreman_scm_revision = 'develop',
   String $katello_scm_revision = 'master',
+  String $rex_scm_revision = 'master',
   Boolean $foreman_manage_repo = true,
   Boolean $katello_manage_repo = true,
+  Boolean $rex_manage_repo = true,
 ) inherits katello_devel::params {
   $group = $user
 

--- a/spec/classes/katello_devel_spec.rb
+++ b/spec/classes/katello_devel_spec.rb
@@ -23,6 +23,7 @@ describe 'katello_devel' do
         it { is_expected.to contain_katello_devel__plugin('katello/katello') }
         it { is_expected.to contain_katello_devel__git_repo('foreman') }
         it { is_expected.to contain_katello_devel__git_repo('katello') }
+        it { is_expected.to contain_katello_devel__git_repo('foreman_remote_execution') }
         it { is_expected.to contain_class('katello_devel::database') }
         it { is_expected.not_to contain_katello_devel__bundle('exec rails s -d') }
         it { is_expected.to contain_file('/usr/local/bin/ktest').with_content(%r{^FOREMAN_PATH=/home/vagrant/foreman$}) }
@@ -214,6 +215,32 @@ describe 'katello_devel' do
           it { is_expected.to contain_katello_devel__plugin('katello/katello') }
           it { is_expected.not_to contain_katello_devel__git_repo('katello') }
         end
+
+        context 'with unmanaged foreman_remote_execution repo' do
+          let(:params) do
+            {
+              :user => 'vagrant',
+              :rex_manage_repo => false,
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_katello_devel__plugin('theforeman/foreman_remote_execution') }
+          it { is_expected.not_to contain_katello_devel__git_repo('foreman_remote_execution') }
+        end
+      end
+
+      context 'with custom foreman_remote_execution repo revision' do
+        let(:params) do
+          {
+            :user => 'vagrant',
+            :rex_scm_revision => '1.2.z',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_katello_devel__plugin('theforeman/foreman_remote_execution') }
+        it { is_expected.to contain_katello_devel__git_repo('foreman_remote_execution').with_revision('1.2.z') }
       end
     end
   end


### PR DESCRIPTION
Thus adding an argument to foreman-installer scenario for setting the scm-revision of foreman_remote_execution.

This makes adding it as extra-plugin in [forklift](https://github.com/theforeman/forklift/blob/ddc5af78ed525e89e86ca35b560f08cdbe70c506/roles/katello_devel/meta/main.yml#L25) obsolete and enables setting the scm-revision with `--katello-devel-rex-scm-revision`.