### PR TITLE
Evaluate plugin gemfiles during bundle operations

### DIFF
--- a/templates/plugin.local.rb.erb
+++ b/templates/plugin.local.rb.erb
@@ -1,1 +1,4 @@
 gemspec :path => '../<%= scope['plugin'] %>', :development_group => '<%= scope['plugin'] %>_dev', :name => '<%= scope['plugin'] %>'
+Dir['../<%= scope['plugin'] %>/gemfile.d/*.rb'].each do |file|
+  eval_gemfile(file)
+end


### PR DESCRIPTION
### Details
[SAT-26017](https://issues.redhat.com/browse/SAT-26017)

This PR exists to mitigate the issues popping up for gem dependencies when running local testing on a katello devel environment. All katello gem dependencies are now added to the foreman bundler.d directory during a full foreman/katello install.

[Previous forklift PR](https://github.com/theforeman/forklift/pull/1835)

### Testing Steps
1. In forklift, create a new katello-devel environment by modifying your `99-local.yaml` config file.
2. Under ansible -> variables -> foreman_installer_module_prs, add the following line: `- theforeman/katello_devel/305` [[Documentation]](https://theforeman.github.io/forklift/development/#test-puppet-module)
3. Create and provision the environment. Beyond normal foreman install issues, everything should go smoothly. The clone puppet module task is most important and should look similar to this:
```
TASK [foreman_installer : Clone puppet module] *********************************
changed: [centos9-katello-devel-2]
 [started TASK: foreman_installer : fetch git PR on centos9-katello-devel-2]
 [started TASK: foreman_installer : install module branches into installer directory on centos9-katello-devel-2]
```
4. Inspect the contents of `~/foreman/bundler.d/katello.local.rb`. It should look similar:
```
gemspec :path => '../katello', :development_group => 'katello_dev', :name => 'katello'
Dir['../katello/gemfile.d/*.rb'].each do |file|
    eval_gemfile(file)
end[vagrant@centos9-katello-devel-2
```
5. `bundle install` and launch foreman/katello. Everything should work as normal. Running ktest should now work on the local environment.