### PR TITLE
Add puppet-dns to fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,6 +12,7 @@ fixtures:
     concat:        "https://github.com/puppetlabs/puppetlabs-concat.git"
     xinetd:        "https://github.com/puppetlabs/puppetlabs-xinetd.git"
     certs:         "https://github.com/theforeman/puppet-certs.git"
+    dns:           "https://github.com/theforeman/puppet-dns.git"
     katello:       "https://github.com/theforeman/puppet-katello.git"
     candlepin:     "https://github.com/theforeman/puppet-candlepin.git"
     foreman:       "https://github.com/theforeman/puppet-foreman.git"


### PR DESCRIPTION
This appears needed since https://github.com/theforeman/puppet-dns/commit/3f53f46ee50a5476504e227164680f0bd548c8b6