### PR TITLE
Drop rake webpack:compile

### DIFF
--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -16,11 +16,6 @@ class katello_devel::setup (
     "SEED_ADMIN_PASSWORD=${admin_password}",
   ]
 
-  katello_devel::bundle { 'exec rake webpack:compile':
-    require => Katello_devel::Bundle['exec npm install'],
-    before  => Katello_devel::Bundle['exec rake db:migrate'],
-  }
-
   katello_devel::bundle { 'install --retry 3 --jobs 3 --path .vendor':
     environment => ['MAKEOPTS=-j'],
   } ->


### PR DESCRIPTION
For some reason this seems to depend on db being migrated, currently the webpack compile step fails like this https://gist.github.com/lumarel/3d04de883cc14deb7f5cff12b0ea2e30 .

Afaik it shouldn't be necessary anymore, if foreman is started with the provided procfile, webpack should be watching the directory and compiling assets on the fly.

An alternative fix would be to change the ordering.